### PR TITLE
feat: remove search input close icon and add autofocus for import sea…

### DIFF
--- a/src/slots/SearchResult/Cmdk.tsx
+++ b/src/slots/SearchResult/Cmdk.tsx
@@ -15,10 +15,8 @@ import {
   Button,
   InputGroup,
   Input,
-  InputRightElement,
   Divider,
   Hide,
-  Show,
   Spinner,
   chakra,
   Stack,
@@ -28,7 +26,6 @@ import {
   type ComponentWithAs
 } from '@chakra-ui/react';
 import {
-  CloseIcon,
   NotAllowedIcon,
   LinkIcon,
   InfoIcon,
@@ -91,6 +88,7 @@ const Cmdk: FC<SearchResultCommonType> = ({ isOpen, onClose }) => {
         <ChakraCommand>
           <InputGroup>
             <Input
+              autoFocus
               colorScheme="brand"
               border="none"
               borderRadius={0}
@@ -103,17 +101,6 @@ const Cmdk: FC<SearchResultCommonType> = ({ isOpen, onClose }) => {
                 id: 'header.search.placeholder'
               })}
             />
-            <Show above="md">
-              <InputRightElement>
-                <Button
-                  variant="unstyle"
-                  size="xs"
-                  onClick={() => setKeywords('')}
-                >
-                  <CloseIcon />
-                </Button>
-              </InputRightElement>
-            </Show>
           </InputGroup>
           <Divider marginBlock={3} />
           <ChakraList


### PR DESCRIPTION
![Completed](https://badgen.net/badge/Setup/Completed/green) ![917](https://badgen.net/badge/Description%20length/917/green) ![feat/improvesearch](https://badgen.net/badge/Branch/feat%2Fimprovesearch/red) ![yutingzhao1991](https://badgen.net/badge/Contributor/yutingzhao1991/blue) ![1](https://badgen.net/badge/ChangeFiles/1/orange)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature

### 🔗 相关 Issue / Related Issue

close #6

### 💡 需求背景和解决方案 / Background or solution

去掉误导性很强的 close 按钮，很少会用到鼠标点击清除搜索，close 反而会让人以为是关闭弹窗。

另外添加了 autofocus，这个对于搜索体验更重要，用户一般的操作是 cmd+k 唤起搜索，然后输入。

### 📝 更新日志 / Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    remove search input close icon and add autofocus for improve search experience       |
| 🇨🇳 Chinese |     去掉搜索关键词清除按钮并添加自动对焦提升搜索体验     |